### PR TITLE
Fix Addon Loading for specific Characters

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -406,11 +406,6 @@ function frame:ADDON_LOADED(name)
 
 	frame:HookMenuButton()
 
-	for addonIndex = 1, frame.compat.GetNumAddOns() do
-		local addonName = frame.compat.GetAddOnInfo(addonIndex)
-		addonsInitialState[addonName] = frame:IsAddonSelected(addonIndex)
-	end
-
 	for _, v in pairs(modules) do
 		if (v.OnLoad) then
 			v:OnLoad()
@@ -420,6 +415,11 @@ end
 
 function frame:PLAYER_ENTERING_WORLD(...)
 	playerName = UnitName("player")
+
+	for addonIndex = 1, frame.compat.GetNumAddOns() do
+		local addonName = frame.compat.GetAddOnInfo(addonIndex)
+		addonsInitialState[addonName] = frame:IsAddonSelected(addonIndex)
+	end
 
 	for _, v in pairs(modules) do
 		if (v.OnPlayerEnteringWorld) then

--- a/Core.lua
+++ b/Core.lua
@@ -416,9 +416,12 @@ end
 function frame:PLAYER_ENTERING_WORLD(...)
 	playerName = UnitName("player")
 
-	for addonIndex = 1, frame.compat.GetNumAddOns() do
-		local addonName = frame.compat.GetAddOnInfo(addonIndex)
-		addonsInitialState[addonName] = frame:IsAddonSelected(addonIndex)
+	local isInitialLogin, isReloadingUi = ...
+	if (isInitialLogin or isReloadingUi) then
+		for addonIndex = 1, frame.compat.GetNumAddOns() do
+			local addonName = frame.compat.GetAddOnInfo(addonIndex)
+			addonsInitialState[addonName] = frame:IsAddonSelected(addonIndex)
+		end
 	end
 
 	for _, v in pairs(modules) do


### PR DESCRIPTION
Hi,

this is my first Pull Request so i hope everything is fine and sorry for my bad english :)

In my Opinion the initial loading state for Specific Characters Addons was wrong.
Addons which are Loaded by the Character showed as "Modified".

So after  the PLAYER_ENTERING_WORLD Event where i have the playerName i add the InitialState Function. Addons which were marked as "Modfied" but loaded by the Character are not showed as "Modified".

Without Bugfix on Entering World:
![image](https://github.com/Eliote/SimpleAddonManager/assets/42657013/1ce1d330-0db3-47e1-ac67-7ebed40bc097)

With Bugfix on Entering World:
![image](https://github.com/Eliote/SimpleAddonManager/assets/42657013/02116555-0ffb-41e6-9b1a-43191f9caf50)

I haven't tested it much.