### PR TITLE
Tooltip profiles

### DIFF
--- a/AddonListFrame.lua
+++ b/AddonListFrame.lua
@@ -255,7 +255,6 @@ end
 local function UpdateTooltip(self)
 	local addonIndex = self.addon.index
 	local name, title, notes, _, reason, security = frame.compat.GetAddOnInfo(addonIndex)
-	local profilesForAddon = ProfilesInAddon(name)
 
 	GameTooltip:ClearLines();
 	GameTooltip:SetOwner(self, "ANCHOR_NONE")
@@ -292,6 +291,7 @@ local function UpdateTooltip(self)
 		if (self.addon.warning) then
 			GameTooltip:AddLine(self.addon.warning, nil, nil, nil, true);
 		end
+		local profilesForAddon = ProfilesInAddon(name)
 		if profilesForAddon ~= "" then
 			GameTooltip:AddLine(L["Profiles: "] .. C.white:WrapText(profilesForAddon));
 		end

--- a/AddonListFrame.lua
+++ b/AddonListFrame.lua
@@ -235,11 +235,10 @@ local function ProfilesInAddon(name)
 	local profilesForAddon = ""
 	local profilesTable = {}
 	for profileNameTable, subPair in pairs(setsList) do
-		local subProfileName, subSet = profileNameTable, subPair
-		local list = subSet.addons
+		local list = subPair.addons
 		for i, _ in pairs(list) do
 			if name == i then
-				table.insert(profilesTable, subProfileName)
+				table.insert(profilesTable, profileNameTable)
 			end
 		end
 	end

--- a/AddonListFrame.lua
+++ b/AddonListFrame.lua
@@ -231,18 +231,22 @@ end
 
 local function ProfilesInAddon(name)
 	local db = frame:GetDb()
-	local setsList = frame:TableAsSortedPairList(db.sets)
+	local setsList = db.sets
 	local profilesForAddon = ""
-	for _, subPair in ipairs(setsList) do
-		local subProfileName, subSet = subPair.key, subPair.value
-		local list = frame:TableAsSortedPairList(subSet.addons)
-		for i, _ in ipairs(list) do
-			if list[i] then
-				if name == tostring(list[i].key) then
-					profilesForAddon = profilesForAddon .. subProfileName .. ", "
-				end
+	local profilesTable = {}
+	for profileNameTable, subPair in pairs(setsList) do
+		local subProfileName, subSet = profileNameTable, subPair
+		local list = subSet.addons
+		for i, _ in pairs(list) do
+			if name == i then
+				table.insert(profilesTable, subProfileName)
 			end
 		end
+	end
+
+	table.sort(profilesTable)
+	for _, profileName in ipairs(profilesTable) do
+		profilesForAddon = profilesForAddon .. profileName .. ", "
 	end
 	-- Remove Last 2 Characters cause whitespace and ','
 	profilesForAddon = string.sub(profilesForAddon, 0, strlen(profilesForAddon) - 2)

--- a/AddonListFrame.lua
+++ b/AddonListFrame.lua
@@ -318,7 +318,7 @@ local function ShouldColorStatus(enabled, loaded, reason)
 		return false
 	end
 	return (enabled and not loaded) or
-		(enabled and loaded and reason == "INTERFACE_VERSION")
+			(enabled and loaded and reason == "INTERFACE_VERSION")
 end
 
 local function UpdateExpandOrCollapseButtonState(button, isCollapsed)
@@ -392,8 +392,8 @@ local function UpdateList()
 			if showExpandOrCollapseButton then
 				button.ExpandOrCollapseButton:Show()
 				UpdateExpandOrCollapseButtonState(
-					button.ExpandOrCollapseButton,
-					isCollapsed
+						button.ExpandOrCollapseButton,
+						isCollapsed
 				)
 			else
 				button.ExpandOrCollapseButton:Hide()

--- a/AddonListFrame.lua
+++ b/AddonListFrame.lua
@@ -234,7 +234,7 @@ local function ProfilesInAddon(name)
 	local setsList = frame:TableAsSortedPairList(db.sets)
 	local profilesForAddon = ""
 	for _, subPair in ipairs(setsList) do
-		subProfileName, subSet = subPair.key, subPair.value
+		local subProfileName, subSet = subPair.key, subPair.value
 		local list = frame:TableAsSortedPairList(subSet.addons)
 		for i, _ in ipairs(list) do
 			if list[i] then

--- a/AddonListFrame.lua
+++ b/AddonListFrame.lua
@@ -318,7 +318,7 @@ local function ShouldColorStatus(enabled, loaded, reason)
 		return false
 	end
 	return (enabled and not loaded) or
-			(enabled and loaded and reason == "INTERFACE_VERSION")
+		(enabled and loaded and reason == "INTERFACE_VERSION")
 end
 
 local function UpdateExpandOrCollapseButtonState(button, isCollapsed)
@@ -392,8 +392,8 @@ local function UpdateList()
 			if showExpandOrCollapseButton then
 				button.ExpandOrCollapseButton:Show()
 				UpdateExpandOrCollapseButtonState(
-						button.ExpandOrCollapseButton,
-						isCollapsed
+					button.ExpandOrCollapseButton,
+					isCollapsed
 				)
 			else
 				button.ExpandOrCollapseButton:Hide()

--- a/AddonListFrame.lua
+++ b/AddonListFrame.lua
@@ -256,7 +256,7 @@ end
 local function UpdateTooltip(self)
 	local addonIndex = self.addon.index
 	local name, title, notes, _, reason, security = frame.compat.GetAddOnInfo(addonIndex)
-	local ProfilesForAddon = ProfilesInAddon(name)
+	local profilesForAddon = ProfilesInAddon(name)
 
 	GameTooltip:ClearLines();
 	GameTooltip:SetOwner(self, "ANCHOR_NONE")
@@ -293,8 +293,8 @@ local function UpdateTooltip(self)
 		if (self.addon.warning) then
 			GameTooltip:AddLine(self.addon.warning, nil, nil, nil, true);
 		end
-		if ProfilesForAddon ~= "" then
-			GameTooltip:AddLine(L["Profiles: "] .. C.white:WrapText(ProfilesForAddon));
+		if profilesForAddon ~= "" then
+			GameTooltip:AddLine(L["Profiles: "] .. C.white:WrapText(profilesForAddon));
 		end
 		GameTooltip:AddLine(" ");
 		GameTooltip:AddLine(notes, 1.0, 1.0, 1.0, true);

--- a/AddonListFrame.lua
+++ b/AddonListFrame.lua
@@ -229,9 +229,30 @@ local function AddonButtonOnClick(self, mouseButton)
 	end
 end
 
+local function ProfilesInAddon(name)
+	local db = frame:GetDb()
+	local setsList = frame:TableAsSortedPairList(db.sets)
+	local ProfilesForAddon = ""
+	for _, subPair in ipairs(setsList) do
+		subProfileName, subSet = subPair.key, subPair.value
+		local list = frame:TableAsSortedPairList(subSet.addons)
+		for i, _ in ipairs(list) do
+			if list[i] then
+				if name == tostring(list[i].key) then
+					ProfilesForAddon = ProfilesForAddon .. subProfileName .. ", "
+				end
+			end
+		end
+	end
+	-- Remove Last 2 Characters cause whitespace and ','
+	ProfilesForAddon = string.sub(ProfilesForAddon, 0, strlen(ProfilesForAddon) - 2)
+	return ProfilesForAddon
+end
+
 local function UpdateTooltip(self)
 	local addonIndex = self.addon.index
 	local name, title, notes, _, reason, security = frame.compat.GetAddOnInfo(addonIndex)
+	local ProfilesForAddon = ProfilesInAddon(name)
 
 	GameTooltip:ClearLines();
 	GameTooltip:SetOwner(self, "ANCHOR_NONE")
@@ -268,6 +289,9 @@ local function UpdateTooltip(self)
 		if (self.addon.warning) then
 			GameTooltip:AddLine(self.addon.warning, nil, nil, nil, true);
 		end
+		if ProfilesForAddon ~= "" then
+			GameTooltip:AddLine(L["Profiles: "] .. C.white:WrapText(ProfilesForAddon));
+		end
 		GameTooltip:AddLine(" ");
 		GameTooltip:AddLine(notes, 1.0, 1.0, 1.0, true);
 		GameTooltip:AddLine(" ");
@@ -294,7 +318,7 @@ local function ShouldColorStatus(enabled, loaded, reason)
 		return false
 	end
 	return (enabled and not loaded) or
-			(enabled and loaded and reason == "INTERFACE_VERSION")
+		(enabled and loaded and reason == "INTERFACE_VERSION")
 end
 
 local function UpdateExpandOrCollapseButtonState(button, isCollapsed)
@@ -368,8 +392,8 @@ local function UpdateList()
 			if showExpandOrCollapseButton then
 				button.ExpandOrCollapseButton:Show()
 				UpdateExpandOrCollapseButtonState(
-						button.ExpandOrCollapseButton,
-						isCollapsed
+					button.ExpandOrCollapseButton,
+					isCollapsed
 				)
 			else
 				button.ExpandOrCollapseButton:Hide()

--- a/AddonListFrame.lua
+++ b/AddonListFrame.lua
@@ -293,7 +293,7 @@ local function UpdateTooltip(self)
 		end
 		local profilesForAddon = ProfilesInAddon(name)
 		if profilesForAddon ~= "" then
-			GameTooltip:AddLine(L["Profiles: "] .. C.white:WrapText(profilesForAddon));
+			GameTooltip:AddLine(L["Profiles: "] .. C.white:WrapText(profilesForAddon), nil, nil, nil, true);
 		end
 		GameTooltip:AddLine(" ");
 		GameTooltip:AddLine(notes, 1.0, 1.0, 1.0, true);

--- a/AddonListFrame.lua
+++ b/AddonListFrame.lua
@@ -232,21 +232,21 @@ end
 local function ProfilesInAddon(name)
 	local db = frame:GetDb()
 	local setsList = frame:TableAsSortedPairList(db.sets)
-	local ProfilesForAddon = ""
+	local profilesForAddon = ""
 	for _, subPair in ipairs(setsList) do
 		subProfileName, subSet = subPair.key, subPair.value
 		local list = frame:TableAsSortedPairList(subSet.addons)
 		for i, _ in ipairs(list) do
 			if list[i] then
 				if name == tostring(list[i].key) then
-					ProfilesForAddon = ProfilesForAddon .. subProfileName .. ", "
+					profilesForAddon = profilesForAddon .. subProfileName .. ", "
 				end
 			end
 		end
 	end
 	-- Remove Last 2 Characters cause whitespace and ','
-	ProfilesForAddon = string.sub(ProfilesForAddon, 0, strlen(ProfilesForAddon) - 2)
-	return ProfilesForAddon
+	profilesForAddon = string.sub(profilesForAddon, 0, strlen(profilesForAddon) - 2)
+	return profilesForAddon
 end
 
 local function UpdateTooltip(self)


### PR DESCRIPTION
Hi again 😄,

This time i've added Profiles in the Tooltip if you hover over an Addon.

This helps if you have Profiles with a dependency on other Profiles and want to know where the addon is.
![image](https://github.com/Eliote/SimpleAddonManager/assets/42657013/4c6e7803-8e5d-4f24-968a-0fe573836bd9)
If the Addon is not in an Profile this line dosn't show.

Probably my integration is not so fancy :/