### PR TITLE
Use player GUID for C_AddOn functions

### DIFF
--- a/AddonListFrame.lua
+++ b/AddonListFrame.lua
@@ -236,7 +236,7 @@ local function Checkbox_SetAddonState(self, enabled, addonIndex)
 		local enabledSome = (not togglingMe) and SAM:IsAddonSelected(addonIndex, true)
 		if (enabledSome) then
 			self:SetChecked(true)
-			local character = SAM:GetSelectedCharName()
+			local character = SAM:GetSelectedCharGUID()
 			local isEnabledByMe = SAM.compat.GetAddOnEnableState(addonIndex, character) == 2
 			if (isEnabledByMe) then
 				checkedTexture:SetVertexColor(0.4, 1.0, 0.4)
@@ -349,7 +349,7 @@ local function CharactersWithAddon(name)
 	table.sort(charList, function(a, b) return a.name < b.name end)
 
 	for _, info in ipairs(charList) do
-		if SAM.compat.GetAddOnEnableState(name, info.name) == 2 then
+		if SAM.compat.GetAddOnEnableState(name, info.guid) == 2 then
 			local _, _, _, hex = GetClassColor(info.class)
 			tinsert(charTbl, WrapTextInColorCode(info.name, hex))
 		end

--- a/CategoryFrame.lua
+++ b/CategoryFrame.lua
@@ -161,10 +161,10 @@ local fixedCategories = {
 		name = C.red:WrapText(L["Addons being modified"]),
 		description = L["Addons being modified in this session"],
 		addons = function(_, key)
-			return SAM:DidAddonStateChanged(key, SAM:GetSelectedCharName())
+			return SAM:DidAddonStateChanged(key, SAM:GetSelectedCharGUID())
 		end,
 		show = function()
-			return SAM:DidAnyAddonStateChanged(SAM:GetSelectedCharName())
+			return SAM:DidAnyAddonStateChanged(SAM:GetSelectedCharGUID())
 		end,
 		count = CommonCountFunction
 	},

--- a/MainFrame.lua
+++ b/MainFrame.lua
@@ -20,12 +20,15 @@ local function CharacterDropDown_Initialize()
 			local _, _, _, hex = GetClassColor(v.class)
 			coloredName = "|c" .. hex .. coloredName .. "|r"
 		end
+		if v.name == v.guid then
+			coloredName = coloredName .. "*"
+		end
 		EDDM.UIDropDownMenu_AddButton({
 			text = coloredName,
 			value = zeroIndex,
 			func = function(self)
 				local value = self.value
-				SAM:InitAddonStateFor(name)
+				SAM:InitAddonStateFor(v.guid)
 				SAM:SetSelectedCharIndex(value)
 				EDDM.UIDropDownMenu_SetSelectedValue(SAM.CharacterDropDown, value)
 				SAM.AddonListFrame.ScrollFrame.update()
@@ -54,7 +57,7 @@ function SAM:DidAnyAddonStateChanged(character)
 end
 
 function SAM:UpdateOkButton()
-	if (SAM:DidAnyAddonStateChanged(SAM:GetCurrentPlayerInfo().name)) then
+	if (SAM:DidAnyAddonStateChanged(SAM:GetCurrentPlayerInfo().guid)) then
 		SAM.edited = true
 		SAM.OkButton:SetText(L["Reload UI"])
 	else

--- a/MainFrame.lua
+++ b/MainFrame.lua
@@ -28,7 +28,7 @@ local function CharacterDropDown_Initialize()
 			value = zeroIndex,
 			func = function(self)
 				local value = self.value
-				SAM:InitAddonStateFor(v.guid)
+				SAM:InitAddonStateFor(name == ALL and true or v.guid)
 				SAM:SetSelectedCharIndex(value)
 				EDDM.UIDropDownMenu_SetSelectedValue(SAM.CharacterDropDown, value)
 				SAM.AddonListFrame.ScrollFrame.update()

--- a/Profile.lua
+++ b/Profile.lua
@@ -474,7 +474,7 @@ function module:UpdatePlayerProfileAddons()
 	local addons = {}
 	for addonIndex = 1, SAM.compat.GetNumAddOns() do
 		local addonName = SAM.compat.GetAddOnInfo(addonIndex)
-		if (SAM.compat.GetAddOnEnableState(addonIndex, playerInfo.name) > 0) then
+		if (SAM.compat.GetAddOnEnableState(addonIndex, playerInfo.guid) > 0) then
 			addons[addonName] = true
 		end
 	end
@@ -482,7 +482,8 @@ function module:UpdatePlayerProfileAddons()
 	db.autoProfile[playerInfo.id] = {
 		addons = addons,
 		playerId = playerInfo.id,
-		playerColor = playerInfo.color.colorStr
+		playerColor = playerInfo.color.colorStr,
+		playerGuid = playerInfo.guid,
 	}
 end
 


### PR DESCRIPTION
I decided to do a rough pass fix for #47 after all.

I seem to have gotten it working. First a lot of variable names could be renamed. Second, it does fallback to using their name if you've not logged into them since, so you can still modify their addons. And an asterisks is added to the dropdown list to indicate they are not updated yet.

I'm also sure there's a lot more places that need to be touched. What do you think? 