### PR TITLE
Add slash commands to enable/disable categories

### DIFF
--- a/CategoryFrame.lua
+++ b/CategoryFrame.lua
@@ -61,10 +61,7 @@ local function CategoryMenu(categoryKey, categoryName)
 			notCheckable = true,
 			disabled = db.categories[categoryKey] == nil,
 			func = function()
-				for name, _ in pairs(db.categories[categoryKey].addons) do
-					SAM:EnableAddOn(name)
-				end
-				SAM:Update()
+				module:EnableCategory(categoryKey)
 			end
 		},
 		{
@@ -72,10 +69,7 @@ local function CategoryMenu(categoryKey, categoryName)
 			notCheckable = true,
 			disabled = db.categories[categoryKey] == nil,
 			func = function()
-				for name, _ in pairs(db.categories[categoryKey].addons) do
-					SAM:DisableAddOn(name)
-				end
-				SAM:Update()
+				module:DisableCategory(categoryKey)
 			end
 		},
 		T.separatorInfo,
@@ -477,6 +471,22 @@ local function RenameInvalidDb(table, name, index)
 	end
 	db.categories[newName] = table
 	table.name = newName
+end
+
+function module:EnableCategory(categoryKey)
+	local db = SAM:GetDb()
+	for name, _ in pairs(db.categories[categoryKey].addons) do
+		SAM:EnableAddOn(name)
+	end
+	SAM:Update()
+end
+
+function module:DisableCategory(categoryKey)
+	local db = SAM:GetDb()
+	for name, _ in pairs(db.categories[categoryKey].addons) do
+		SAM:DisableAddOn(name)
+	end
+	SAM:Update()
 end
 
 function module:PreInitialize()

--- a/SlashCommand.lua
+++ b/SlashCommand.lua
@@ -89,6 +89,73 @@ local Commands = {
 			end
 		end,
 	},
+	category = {
+		usage = 'category "name" [OPTION]...',
+		args = {
+			{ desc = 'Name: Category name', required = true },
+			{
+				desc = [==[Reload option (optional):
+- ask: Show confirmation popup (default)
+- reload: Reload the UI
+- ignore: Apply changes without reload]==],
+				required = false
+			},
+			{
+				desc = [==[Load option (optional):
+- enable: Enable all addons from the category
+- disable: Disable all addons from the category]==],
+				required = false
+			},
+		},
+		func = function (category,...)
+			local db = SAM:GetDb()
+			if (not db.categories[category]) then
+				CommandsModule:Print(L("Category '${category}' not found!", { category = category }))
+				return
+			else
+				local args = { ... }
+				local reloadOptions = { "ask", "reload", "ignore" }
+				local error, reloadType = CommandsModule:FindUniqueOptionInArgs(args, reloadOptions, "ask")
+				if (error) then return CommandsModule:Print(reloadType) end
+
+				local loadOptions = {"enable", "disable" }
+				local error, loadType = CommandsModule:FindUniqueOptionInArgs(args, loadOptions, "load")
+				if (error) then return CommandsModule:Print(loadType) end
+
+				if (loadType == "enable") then
+					if (reloadType == "ask") then
+						SAM:ShowConfirmDialog(
+								L("Enable addons from the category '${category}' and reload UI?", { category = category }),
+								function()
+									SAM:GetModule("Category"):EnableCategory(category)
+									ReloadUI()
+								end
+						)
+					else
+						SAM:GetModule("Category"):EnableCategory(category)
+						if (reloadType == "reload") then
+							ReloadUI()
+						end
+					end
+				elseif (loadType == "disable") then
+					if (reloadType == "ask") then
+						SAM:ShowConfirmDialog(
+								L("Disable addons from the category '${category}' and reload UI?", { category = category }),
+								function()
+									SAM:GetModule("Category"):DisableCategory(category)
+									ReloadUI()
+								end
+						)
+					else
+						SAM:GetModule("Category"):DisableCategory(category)
+						if (reloadType == "reload") then
+							ReloadUI()
+						end
+					end
+				end
+			end
+		end
+	},
 }
 
 LibStub("AceConsole-3.0"):Embed(CommandsModule)


### PR DESCRIPTION
This PR adds additional slash commands to SAM, specifically `/sam category "name" [OPTION]...`

It follows the same structure as `/sam profile "name" [OPTION]...`

Reload Options:
- `ask` - give a UI popup asking to enable/disable addons in category and reload
- `reload` - enables/disables addons and reloads
- `ignore` - enables/disables category and does not reload

Load Options:
- `enable`
- `disable`
- no `load` load option because it's not relevant for categories