### PR TITLE
change editBox calls to GetEditBox()

### DIFF
--- a/CategoryFrame.lua
+++ b/CategoryFrame.lua
@@ -34,8 +34,8 @@ local function CategoryMenu(categoryKey, categoryName)
 							SAM:Update()
 						end,
 						function(self)
-							self.editBox:SetText(categoryName)
-							self.editBox:HighlightText()
+							self:GetEditBox():SetText(categoryName)
+							self:GetEditBox():HighlightText()
 						end
 				)
 			end

--- a/Core.lua
+++ b/Core.lua
@@ -126,8 +126,8 @@ function SAM:ShowDialog(dialogInfo)
 			self:SetPoint("TOP", SAM, "TOP", 0, -120)
 		end
 		self.OldStrata = self:GetFrameStrata()
-		if (self.editBox) then
-			self.editBox:SetText("")
+		if (self:GetEditBox()) then
+			self:GetEditBox():SetText("")
 		end
 		if (dialogInfo.funcOnShow) then
 			dialogInfo.funcOnShow(self, ...)
@@ -157,7 +157,7 @@ function SAM:ShowInputDialog(text, func, funcOnShow, button2)
 		text = text,
 		hasEditBox = true,
 		funcAccept = function(self)
-			func(self.editBox:GetText())
+			func(self:GetEditBox():GetText())
 		end,
 		funcOnShow = funcOnShow,
 		hideOnEscape = true,

--- a/Profile.lua
+++ b/Profile.lua
@@ -366,9 +366,9 @@ local function ProfilesDropDownCreate()
 								L["Export text"],
 								function() end,
 								function(self)
-									self.editBox:SetText(data)
-									self.editBox:HighlightText()
-									self.editBox:SetFocus()
+									self:GetEditBox():SetText(data)
+									self:GetEditBox():HighlightText()
+									self:GetEditBox():SetFocus()
 								end,
 								false
 						)
@@ -386,8 +386,8 @@ local function ProfilesDropDownCreate()
 									db.sets[profileName] = nil
 								end,
 								function(self)
-									self.editBox:SetText(profileName)
-									self.editBox:HighlightText()
+									self:GetEditBox():SetText(profileName)
+									self:GetEditBox():HighlightText()
 								end
 						)
 					end
@@ -422,8 +422,8 @@ local function ProfilesDropDownCreate()
 						module:ImportProfile(text)
 					end,
 					function(self)
-						self.editBox:SetText("")
-						self.editBox:SetFocus()
+						self:GetEditBox():SetText("")
+						self:GetEditBox():SetFocus()
 					end
 			)
 		end


### PR DESCRIPTION
Fixes #60
StaticPopupDialogs changed functionality with calls on editBox to now only use GetEditBox(), changed all references to it
